### PR TITLE
dbus/1.15.8: bump expat version to 2.6.0

### DIFF
--- a/recipes/dbus/1.x.x/conanfile.py
+++ b/recipes/dbus/1.x.x/conanfile.py
@@ -67,7 +67,7 @@ class DbusConan(ConanFile):
         basic_layout(self, src_folder="src")
 
     def requirements(self):
-        self.requires("expat/2.5.0")
+        self.requires("expat/2.6.0")
         if self.options.with_glib:
             self.requires("glib/2.77.0")
         if self.options.get_safe("with_systemd"):


### PR DESCRIPTION
This fixes Qt compilation (version 5.15.12) when using _with_dbus_ option to True.

---

- [X] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [X] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [X] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
